### PR TITLE
Flag for SSL/TLS for GSA

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ wget https://raw.githubusercontent.com/Kastervo/OpenVAS-Installation/master/open
 ```
 ./openvas_install.sh
 ```
+#### Flags
+```
+-S 	# Enable HTTPs on the greenbone webpage
+```
 
 ### ⚙ Step #4: The admin password.
 

--- a/openvas_install.sh
+++ b/openvas_install.sh
@@ -470,7 +470,8 @@ if [[ "$@" == *"-S"* ]]; then
     [Install]
     WantedBy=multi-user.target
     Alias=greenbone-security-assistant.service
-    EOF
+
+EOF
 else
     cat << EOF > $BUILD_DIR/gsad.service
     [Unit]
@@ -493,7 +494,8 @@ else
     [Install]
     WantedBy=multi-user.target
     Alias=greenbone-security-assistant.service
-    EOF
+    
+EOF
 fi
 cp -v $BUILD_DIR/gsad.service /etc/systemd/system/
 

--- a/openvas_install.sh
+++ b/openvas_install.sh
@@ -58,7 +58,7 @@ export OPENVAS_GNUPG_HOME=/etc/openvas/gnupg
 
 # Create user
 
-getent passwd gvm > /dev/null 2&>1
+getent passwd gvm > /dev/null 2>&1
 
 if [ $? -eq 0 ]; then
     echo "GVM User already exists."

--- a/openvas_install.sh
+++ b/openvas_install.sh
@@ -463,7 +463,7 @@ if [[ "$@" == *"-S"* ]]; then
     RuntimeDirectoryMode=2775
     PIDFile=/run/gsad/gsad.pid
     #ExecStart=/usr/local/sbin/gsad --foreground --listen=0.0.0.0 --port=9392 --http-only
-    ExecStart=/usr/local/sbin/gsad --listen=0.0.0.0 --drop-privleges=gvm --port=443 --rport=80 -k /etc/gvm/serverkey.pem -c /etc/gvm/servercert.pem
+    ExecStart=/usr/local/sbin/gsad --listen=0.0.0.0 --drop-privileges=gvm --port=443 --rport=80 -k /etc/gvm/serverkey.pem -c /etc/gvm/servercert.pem
     Restart=always
     TimeoutStopSec=10
 


### PR DESCRIPTION
I realized that your script did not offer any option for users to have GSA served over https. In these commits I included the flag and explained what it does very briefly in the README. Let me know if you would like any improvements